### PR TITLE
动态计算indexTagView宽度

### DIFF
--- a/AAPageController/AAPageController.swift
+++ b/AAPageController/AAPageController.swift
@@ -208,8 +208,19 @@ extension AAPageController: UIPageViewControllerDataSource, UIPageViewController
             topBar.scrollToItem(at: currentIndexPath, at: .centeredHorizontally, animated: true)
             topBar.reloadItems(at: topBar.indexPathsForVisibleItems)
             delegate?.pageController(self, didDisplayedChildAt: currentIndex)
+            
+            let title = dataSource?.titlesForChildControllers(pageController: self, index: currentIndexPath.item) ?? ""
+            var font = currentIndexPath.item == currentIndex ? topBarItemSelectedFont : topBarItemFont
+            font = font ?? topBarItemFont
+            let rect = NSString.init(string: title).boundingRect(with: .init(width: 0, height: topBarHeight), options: .usesLineFragmentOrigin, attributes: [.font: font!], context: nil)
+            
             if let frame = layout.layoutAttributesForItem(at: currentIndexPath)?.frame {
                 UIView.animate(withDuration: 0.35) {
+                    
+                    var tempB = self.indexTagView.bounds
+                    tempB.size.width = rect.width - 5
+                    self.indexTagView.bounds = tempB
+                    
                     self.indexTagView.center.x = frame.midX
                 }
             }


### PR DESCRIPTION
动态计算indexTagView宽度，确保其与文字长度相等。
参数 indexTagViewWidth 可以TODO：等于0时自动计算，其它使用固定值。